### PR TITLE
Allow client to be provided as argument

### DIFF
--- a/src/redisCache.ts
+++ b/src/redisCache.ts
@@ -28,7 +28,7 @@ export class RedisCache<V = any> implements SortKeyCache<V> {
   isAtomic: boolean;
 
   constructor(cacheOptions: CacheOptions, redisOptions: RedisOptions) {
-    // open client
+    // create client
     if (redisOptions.client) {
       // client is managed from outside
       this.client = redisOptions.client;
@@ -43,12 +43,17 @@ export class RedisCache<V = any> implements SortKeyCache<V> {
 
     // open client and set config
     this.open().then(() => {
-      if (cacheOptions.inMemory) {
-        // see: How to disable Redis RDB and AOF? https://stackoverflow.com/a/34736871/21699616
-        // https://redis.io/docs/management/persistence/#append-only-file
-        this.client.CONFIG_SET("appendonly", "no");
-        // https://redis.io/docs/management/persistence/#snapshotting
-        this.client.CONFIG_SET("save", "");
+      if (this.isManaged) {
+        // cant change config settings if client is not managed by Warp
+        this.logger.warn("Client is managed by user, not changing config.");
+      } else {
+        if (cacheOptions.inMemory) {
+          // see: How to disable Redis RDB and AOF? https://stackoverflow.com/a/34736871/21699616
+          // https://redis.io/docs/management/persistence/#append-only-file
+          this.client.CONFIG_SET("appendonly", "no");
+          // https://redis.io/docs/management/persistence/#snapshotting
+          this.client.CONFIG_SET("save", "");
+        }
       }
     });
 

--- a/src/types/redisCache.ts
+++ b/src/types/redisCache.ts
@@ -1,13 +1,16 @@
+import type { RedisClientType } from "@redis/client";
+
 /**
  * Redis client options.
- * - `url`
+ * - `url` Redis URL
  * - `isAtomic` temporarily disables atomic operations
- * - `isManaged` temporarily disables atomic operations
+ * - `client` provide the RedisClient yourself, internally disables `open` and `close` calls
+ * and expects you to do them outside to your client manually.
  */
 export type RedisOptions = {
   url: string;
   maxEntriesPerContract?: number;
   minEntriesPerContract?: number;
   isAtomic?: boolean;
-  isManaged?: boolean;
+  client?: RedisClientType;
 };


### PR DESCRIPTION
If `RedisClient` is provided from outside, `open` and `close` functions are disabled and we expect the client to be managed by the user. This includes changing the config yourself if `inMemory: true`.