### PR TITLE
fixed deletion, updated tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can see if the client is managed or not via the `isManaged` field.
 
 ### Lua Scripts
 
-Some of the functionality is achieved via Lua scripts, which you can find under `src/lua` for _reference_; the actual scripts are written in `luaScripts.ts`. The `prefix` and `subLevelSeparator` must be provided as argument to Lua scripts, because multiple RedisCache instances may be created with different prefixes or sub-level separators but they may connect to the same client; and for that reason we can't simply hardcode them in the script.
+Some of the functionality is achieved via Lua scripts (v5.1), which you can find under `src/lua` for _reference_; the actual scripts are written in `luaScripts.ts`. The `prefix` and `subLevelSeparator` must be provided as argument to Lua scripts, because multiple RedisCache instances may be created with different prefixes or sub-level separators but they may connect to the same client; and for that reason we can't simply hardcode them in the script.
 
 ## Installation
 

--- a/src/lua/del.lua
+++ b/src/lua/del.lua
@@ -1,8 +1,12 @@
+-- DEPRACATED: we are not deleting this way!
+-- instead, we set the key to be deleted by updating it with empty string.
+
 local key = KEYS[1]
 local sortKey = KEYS[2]
 local prefix = ARGV[1]
 local sls = ARGV[2]
 
+-- remove everything less-than or equal-to this sortKey under the given key
 local cacheKeysToRemove = redis.call(
   "ZRANGE",
   prefix .. ".keys",
@@ -11,6 +15,7 @@ local cacheKeysToRemove = redis.call(
   "BYLEX"
 )
 
+-- also remove them from the sorted set
 redis.call("ZREM", prefix .. ".keys", unpack(cacheKeysToRemove))
 for _, cacheKey in pairs(cacheKeysToRemove) do
   redis.call("DEL", prefix .. "." .. cacheKey)

--- a/src/luaScripts.ts
+++ b/src/luaScripts.ts
@@ -8,34 +8,9 @@
  * - `readOnly` is an additional option, where if true, the script is treated as read-only. See
  * the relevant section here: {@link https://redis.io/docs/manual/programmability/#read-only-scripts}
  */
-type LuaCommandDefintionType = { lua: string; numberOfKeys: number; readOnly?: boolean };
-
-export const luaScripts: { [name: string]: LuaCommandDefintionType } = {
-  /** {@see [definition](./lua/del.lua)} */
-  atomic_del: {
-    lua: `
-local key = KEYS[1]
-local sortKey = KEYS[2]
-local prefix = ARGV[1]
-local sls = ARGV[2]
-
-local cacheKeysToRemove = redis.call(
-"ZRANGE",
-prefix .. ".keys",
-"[" .. key .. sls .. sortKey,
-"(" .. key .. sls .. "999999999999,9999999999999,zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
-"BYLEX"
-)
-
-redis.call("ZREM", prefix .. ".keys", unpack(cacheKeysToRemove))
-for _, cacheKey in pairs(cacheKeysToRemove) do
-redis.call("DEL", prefix .. "." .. cacheKey)
-end
-`,
-    numberOfKeys: 2,
-  },
+export const luaScripts: { [name: string]: { lua: string; numberOfKeys: number; readOnly?: boolean } } = {
   /** {@see [definition](./lua/prune.lua)} */
-  atomic_prune: {
+  sortkeycache_atomic_prune: {
     lua: `
 local entriesStored = KEYS[1]
 local prefix = ARGV[1]
@@ -76,7 +51,7 @@ end
     numberOfKeys: 1,
   },
   /** {@see [definition](./lua/put.lua)} */
-  atomic_put: {
+  sortkeycache_atomic_put: {
     lua: `
 local key = KEYS[1]
 local sortKey = KEYS[2]

--- a/src/types/ioredis.d.ts
+++ b/src/types/ioredis.d.ts
@@ -5,22 +5,22 @@ import type { RedisCommander, Result, Callback } from "ioredis";
 declare module "ioredis" {
   interface RedisCommander<Context> {
     // prettier-ignore
-    atomic_del(
-      key: string,
-      sortKey: string,
-      prefix: string,
-      sls: string,
-      callback?: Callback<void>
-    ): Result<void, Context>;
+    // sortkeycache_atomic_del(
+    //   key: string,
+    //   sortKey: string,
+    //   prefix: string,
+    //   sls: string,
+    //   callback?: Callback<void>
+    // ): Result<void, Context>;
     // prettier-ignore
-    atomic_prune(
+    sortkeycache_atomic_prune(
       entriesStored: number,
       prefix: string,
       sls: string,
       callback?: Callback<void>
     ): Result<void, Context>;
     // prettier-ignore
-    atomic_put(
+    sortkeycache_atomic_put(
       key: string,
       sortKey: string,
       value: string,

--- a/test/atomic.test.ts
+++ b/test/atomic.test.ts
@@ -2,24 +2,12 @@ import { RedisCache } from "../src";
 import { getSortKey, makeValue } from "./utils";
 import constants from "./constants";
 
-describe("redis cache atomic transactions", () => {
+describe("atomic transactions", () => {
   let db: RedisCache<number>;
-  const MIN_ENTRIES = 5;
-  const MAX_ENTRIES = 10;
+  const LAST_HEIGHT = 5;
 
   beforeAll(async () => {
-    db = new RedisCache(
-      {
-        inMemory: true,
-        dbLocation: constants.DBNAME,
-        subLevelSeparator: "|",
-      },
-      {
-        minEntriesPerContract: MIN_ENTRIES,
-        maxEntriesPerContract: MAX_ENTRIES,
-        url: constants.REDIS_URL,
-      }
-    );
+    db = new RedisCache(constants.CACHE_OPTS, constants.REDIS_OPTS);
   });
 
   it("should begin & commit a transaction", async () => {
@@ -27,12 +15,12 @@ describe("redis cache atomic transactions", () => {
     await db.begin();
 
     // put some keys
-    for (let i = 1; i <= MIN_ENTRIES; i++) {
+    for (let i = 1; i <= LAST_HEIGHT; i++) {
       await db.put({ key, sortKey: getSortKey(i) }, makeValue(i));
     }
 
     // should get null as they are not yet committed
-    for (let i = 1; i <= MIN_ENTRIES; i++) {
+    for (let i = 1; i <= LAST_HEIGHT; i++) {
       const result = await db.get({ key, sortKey: getSortKey(i) });
       expect(result).toBe(null);
     }
@@ -41,7 +29,7 @@ describe("redis cache atomic transactions", () => {
     await db.commit();
 
     // should get the keys afterwards
-    for (let i = 1; i <= MIN_ENTRIES; i++) {
+    for (let i = 1; i <= LAST_HEIGHT; i++) {
       const result = await db.get({ key, sortKey: getSortKey(i) });
       if (result) {
         expect(result.sortKey).toBe(getSortKey(i));
@@ -57,12 +45,12 @@ describe("redis cache atomic transactions", () => {
     await db.begin();
 
     // put some keys
-    for (let i = 1; i <= MIN_ENTRIES; i++) {
+    for (let i = 1; i <= LAST_HEIGHT; i++) {
       await db.put({ key, sortKey: getSortKey(i) }, makeValue(i));
     }
 
     // should get null as they are not yet committed
-    for (let i = 1; i <= MIN_ENTRIES; i++) {
+    for (let i = 1; i <= LAST_HEIGHT; i++) {
       const result = await db.get({ key, sortKey: getSortKey(i) });
       expect(result).toBe(null);
     }
@@ -71,7 +59,7 @@ describe("redis cache atomic transactions", () => {
     await db.rollback();
 
     // should be null again
-    for (let i = 1; i <= MIN_ENTRIES; i++) {
+    for (let i = 1; i <= LAST_HEIGHT; i++) {
       const result = await db.get({ key, sortKey: getSortKey(i) });
       expect(result).toBe(null);
     }

--- a/test/constants/index.ts
+++ b/test/constants/index.ts
@@ -1,5 +1,16 @@
+import { CacheOptions } from "warp-contracts";
+import { RedisOptions } from "../../src";
+
 export default {
-  DBNAME: "warpcc-redis-test",
-  REDIS_URL: "redis://default:redispw@localhost:6379",
   JEST_AFTERALL_TIMEOUT: 1000,
+  CACHE_OPTS: {
+    inMemory: true,
+    dbLocation: "warpcc-redis-test",
+    subLevelSeparator: "|",
+  } satisfies CacheOptions,
+  REDIS_OPTS: {
+    url: "redis://default:redispw@localhost:6379",
+    minEntriesPerContract: 10,
+    maxEntriesPerContract: 100,
+  } satisfies RedisOptions,
 } as const;

--- a/test/del.test.ts
+++ b/test/del.test.ts
@@ -1,0 +1,67 @@
+import { RedisCache } from "../src";
+import { getSortKey, makeValue } from "./utils";
+import constants from "./constants";
+
+describe("deletion logic", () => {
+  let db: RedisCache<number>;
+  const key = "crudtest";
+  const insertAt = 1;
+  const deleteAt = 5;
+
+  beforeAll(async () => {
+    db = new RedisCache<number>(constants.CACHE_OPTS, constants.REDIS_OPTS);
+
+    // for this test's purposes
+    expect(insertAt).toBeLessThan(deleteAt);
+  });
+
+  it("should set & get a key", async () => {
+    const sortKey = getSortKey(insertAt);
+    const value = makeValue(insertAt);
+    await db.put({ key, sortKey }, value);
+
+    const result = await db.get({ key, sortKey });
+    if (result) {
+      expect(result.sortKey).toBe(sortKey);
+      expect(result.cachedValue).toBe(value);
+    } else {
+      expect(result).not.toBe(null);
+    }
+  });
+
+  it("should delete a key at some height", async () => {
+    const sortKey = getSortKey(deleteAt);
+    await db.del({ key, sortKey });
+
+    const result = await db.get({ key, sortKey });
+    if (result) {
+      expect(result.sortKey).toBe(sortKey);
+      expect(result.cachedValue).toBe(null);
+    } else {
+      expect(result).not.toBe(null);
+    }
+  });
+
+  it("should access the deleted key at a lower height", async () => {
+    const sortKey = getSortKey(insertAt);
+    const value = makeValue(insertAt);
+    const result = await db.get({ key, sortKey });
+    if (result) {
+      expect(result.sortKey).toBe(sortKey);
+      expect(result.cachedValue).toBe(value);
+    } else {
+      expect(result).not.toBe(null);
+    }
+  });
+
+  afterAll(async () => {
+    // clean everything
+    await db.storage().flushdb();
+
+    // need to wait a bit otherwise you get `DisconnectsClientError` error
+    await new Promise((res) => {
+      setTimeout(res, constants.JEST_AFTERALL_TIMEOUT);
+    });
+    await db.close();
+  });
+});

--- a/test/prune.test.ts
+++ b/test/prune.test.ts
@@ -2,7 +2,7 @@ import { RedisCache } from "../src";
 import { getSortKey, makeValue } from "./utils";
 import constants from "./constants";
 
-describe.each<boolean>([true, false])("redis cache prune (atomic: %s)", (isAtomic) => {
+describe.each<boolean>([true, false])("prune (atomic: %s)", (isAtomic) => {
   let db: RedisCache<number>;
   const LAST_HEIGHT = 5;
   const ENTRIES_STORED = 2;
@@ -11,18 +11,7 @@ describe.each<boolean>([true, false])("redis cache prune (atomic: %s)", (isAtomi
 
   beforeAll(async () => {
     expect(ENTRIES_STORED).toBeLessThan(LAST_HEIGHT);
-    db = new RedisCache<number>(
-      {
-        inMemory: true,
-        dbLocation: constants.DBNAME,
-        subLevelSeparator: "|",
-      },
-      {
-        minEntriesPerContract: 10,
-        maxEntriesPerContract: 100,
-        url: constants.REDIS_URL,
-      }
-    );
+    db = new RedisCache<number>(constants.CACHE_OPTS, constants.REDIS_OPTS);
   });
 
   it("should prune keys", async () => {

--- a/test/put.test.ts
+++ b/test/put.test.ts
@@ -2,7 +2,7 @@ import { RedisCache } from "../src";
 import { getSortKey, makeValue } from "./utils";
 import constants from "./constants";
 
-describe.each<boolean>([true, false])("redis cache puts with limit (atomic: %s)", (isAtomic) => {
+describe.each<boolean>([true, false])("put with pruning (atomic: %s)", (isAtomic) => {
   let db: RedisCache<number>;
   const MIN_ENTRIES = 5;
   const MAX_ENTRIES = 10;
@@ -10,18 +10,11 @@ describe.each<boolean>([true, false])("redis cache puts with limit (atomic: %s)"
 
   beforeAll(async () => {
     expect(MIN_ENTRIES).toBeLessThan(MAX_ENTRIES);
-    db = new RedisCache<number>(
-      {
-        inMemory: true,
-        dbLocation: constants.DBNAME,
-        subLevelSeparator: "|",
-      },
-      {
-        minEntriesPerContract: MIN_ENTRIES,
-        maxEntriesPerContract: MAX_ENTRIES,
-        url: constants.REDIS_URL,
-      }
-    );
+    db = new RedisCache<number>(constants.CACHE_OPTS, {
+      ...constants.REDIS_OPTS,
+      minEntriesPerContract: MIN_ENTRIES,
+      maxEntriesPerContract: MAX_ENTRIES,
+    });
   });
 
   it("should put cache keys", async () => {


### PR DESCRIPTION
Deleting a key is simply putting `""` to that key. This way, Redis can differentiate between a `null` response (i.e. key does not exist) versus a `""` response that is a key which is deleted.

If `""` is retrieved from a key, `{cachedValue: null, sortKey}` is returned to Warp. If `null` is retrieved, then it is simply sent as is, indicating to Warp that there is no such key.

Note that this does not prevent one to store `""` at a key, because all values are JSON-stringified beforehand, meaning that `""` would become `"\"\""` during storage.

Relevant: <https://stackoverflow.com/questions/25557250/redis-store-key-without-a-value>